### PR TITLE
Add generic agent support for user-scoped skill installs

### DIFF
--- a/acceptance/testdata/skills/skills-install-scope.txtar
+++ b/acceptance/testdata/skills/skills-install-scope.txtar
@@ -9,5 +9,5 @@ exec gh skill install github/awesome-copilot git-commit --scope user --force --a
 exists $HOME/.copilot/skills/git-commit/SKILL.md
 
 # Install with --scope user can target the generic agent skills directory
-exec gh skill install github/awesome-copilot git-commit --scope user --force --agent generic
+exec gh skill install github/awesome-copilot git-commit --scope user --force --agent generic-agent
 exists $HOME/.agents/skills/git-commit/SKILL.md

--- a/acceptance/testdata/skills/skills-install-scope.txtar
+++ b/acceptance/testdata/skills/skills-install-scope.txtar
@@ -7,3 +7,7 @@ exists $WORK/myrepo/.agents/skills/git-commit/SKILL.md
 # Install with --scope user writes to home directory
 exec gh skill install github/awesome-copilot git-commit --scope user --force --agent github-copilot
 exists $HOME/.copilot/skills/git-commit/SKILL.md
+
+# Install with --scope user can target the generic agent skills directory
+exec gh skill install github/awesome-copilot git-commit --scope user --force --agent generic
+exists $HOME/.agents/skills/git-commit/SKILL.md

--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -51,6 +51,12 @@ var Agents = []AgentHost{
 		UserDir:    ".copilot/skills",
 	},
 	{
+		ID:         "generic",
+		Name:       "Generic agent",
+		ProjectDir: sharedProjectSkillsDir,
+		UserDir:    sharedProjectSkillsDir,
+	},
+	{
 		ID:         "claude-code",
 		Name:       "Claude Code",
 		ProjectDir: ".claude/skills",

--- a/internal/skills/registry/registry.go
+++ b/internal/skills/registry/registry.go
@@ -51,7 +51,7 @@ var Agents = []AgentHost{
 		UserDir:    ".copilot/skills",
 	},
 	{
-		ID:         "generic",
+		ID:         "generic-agent",
 		Name:       "Generic agent",
 		ProjectDir: sharedProjectSkillsDir,
 		UserDir:    sharedProjectSkillsDir,

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -16,6 +16,7 @@ func TestFindByID(t *testing.T) {
 		wantErr  string
 	}{
 		{name: "github-copilot", id: "github-copilot", wantName: "GitHub Copilot"},
+		{name: "generic", id: "generic", wantName: "Generic agent"},
 		{name: "claude-code", id: "claude-code", wantName: "Claude Code"},
 		{name: "cursor", id: "cursor", wantName: "Cursor"},
 		{name: "codex", id: "codex", wantName: "Codex"},
@@ -62,6 +63,14 @@ func TestInstallDir(t *testing.T) {
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",
 			wantDir: filepath.Join("/home/monalisa", ".copilot", "skills"),
+		},
+		{
+			name:    "generic user scope",
+			hostID:  "generic",
+			scope:   ScopeUser,
+			gitRoot: "/tmp/monalisa-repo",
+			homeDir: "/home/monalisa",
+			wantDir: filepath.Join("/home/monalisa", ".agents", "skills"),
 		},
 		{
 			name:    "claude code project scope",

--- a/internal/skills/registry/registry_test.go
+++ b/internal/skills/registry/registry_test.go
@@ -16,7 +16,7 @@ func TestFindByID(t *testing.T) {
 		wantErr  string
 	}{
 		{name: "github-copilot", id: "github-copilot", wantName: "GitHub Copilot"},
-		{name: "generic", id: "generic", wantName: "Generic agent"},
+		{name: "generic agent", id: "generic-agent", wantName: "Generic agent"},
 		{name: "claude-code", id: "claude-code", wantName: "Claude Code"},
 		{name: "cursor", id: "cursor", wantName: "Cursor"},
 		{name: "codex", id: "codex", wantName: "Codex"},
@@ -65,8 +65,8 @@ func TestInstallDir(t *testing.T) {
 			wantDir: filepath.Join("/home/monalisa", ".copilot", "skills"),
 		},
 		{
-			name:    "generic user scope",
-			hostID:  "generic",
+			name:    "generic agent user scope",
+			hostID:  "generic-agent",
 			scope:   ScopeUser,
 			gitRoot: "/tmp/monalisa-repo",
 			homeDir: "/home/monalisa",

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -165,8 +165,8 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 			# Install for Claude Code at user scope
 			$ gh skill install github/awesome-copilot git-commit --agent claude-code --scope user
 
-			# Install to the generic user skills directory
-			$ gh skill install github/awesome-copilot git-commit --agent generic --scope user
+			# Install to the generic ~/.agents/skills directory
+			$ gh skill install github/awesome-copilot git-commit --agent generic-agent --scope user
 
 			# Pin to a specific git ref
 			$ gh skill install github/awesome-copilot git-commit --pin v2.0.0

--- a/pkg/cmd/skills/install/install.go
+++ b/pkg/cmd/skills/install/install.go
@@ -86,8 +86,8 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 			scope (in your home directory, available everywhere).
 
 			A wide range of AI coding agents are supported, including GitHub
-			Copilot, Claude Code, Cursor, Codex, Gemini CLI, Antigravity, Amp,
-			Goose, Junie, OpenCode, Windsurf, and many more.
+			Copilot, Generic agent, Claude Code, Cursor, Codex, Gemini CLI,
+			Antigravity, Amp, Goose, Junie, OpenCode, Windsurf, and many more.
 
 			Supported %[1]s--agent%[1]s values:
 
@@ -97,10 +97,11 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 			custom directory. The default scope is %[1]sproject%[1]s, and the default
 			agent is %[1]sgithub-copilot%[1]s (when running non-interactively).
 
-			At project scope, several agents (including GitHub Copilot, Cursor,
-			Codex, Gemini CLI, Antigravity, Amp, Cline, OpenCode, and Warp) share
-			the %[1]s.agents/skills%[1]s directory. If you select multiple hosts that
-			resolve to the same destination, each skill is installed there only once.
+			At project scope, several agents (including GitHub Copilot, Generic
+			agent, Cursor, Codex, Gemini CLI, Antigravity, Amp, Cline, OpenCode,
+			and Warp) share the %[1]s.agents/skills%[1]s directory. If you select
+			multiple hosts that resolve to the same destination, each skill is
+			installed there only once.
 
 			The first argument is a GitHub repository in %[1]sOWNER/REPO%[1]s format.
 			Use %[1]s--from-local%[1]s to install from a local directory instead.
@@ -163,6 +164,9 @@ func NewCmdInstall(f *cmdutil.Factory, telemetry ghtelemetry.CommandRecorder, ru
 
 			# Install for Claude Code at user scope
 			$ gh skill install github/awesome-copilot git-commit --agent claude-code --scope user
+
+			# Install to the generic user skills directory
+			$ gh skill install github/awesome-copilot git-commit --agent generic --scope user
 
 			# Pin to a specific git ref
 			$ gh skill install github/awesome-copilot git-commit --pin v2.0.0

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -426,7 +426,7 @@ func TestInstallRun(t *testing.T) {
 			wantStdout: "Installed git-commit",
 		},
 		{
-			name:  "remote install with --agent generic and --scope user",
+			name:  "remote install with --agent generic-agent and --scope user",
 			isTTY: true,
 			stubs: func(reg *httpmock.Registry) {
 				stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
@@ -442,7 +442,7 @@ func TestInstallRun(t *testing.T) {
 					GitClient:    &git.Client{RepoDir: t.TempDir()},
 					SkillSource:  "monalisa/skills-repo",
 					SkillName:    "git-commit",
-					Agent:        "generic",
+					Agent:        "generic-agent",
 					Scope:        "user",
 					ScopeChanged: true,
 				}

--- a/pkg/cmd/skills/install/install_test.go
+++ b/pkg/cmd/skills/install/install_test.go
@@ -426,6 +426,37 @@ func TestInstallRun(t *testing.T) {
 			wantStdout: "Installed git-commit",
 		},
 		{
+			name:  "remote install with --agent generic and --scope user",
+			isTTY: true,
+			stubs: func(reg *httpmock.Registry) {
+				stubResolveVersion(reg, "monalisa", "skills-repo", "v1.0.0", "abc123")
+				stubDiscoverTree(reg, "monalisa", "skills-repo", "abc123",
+					singleSkillTreeJSON("git-commit", "treeSHA", "blobSHA"))
+				stubInstallFiles(reg, "monalisa", "skills-repo", "treeSHA", "blobSHA", gitCommitContent)
+			},
+			opts: func(ios *iostreams.IOStreams, reg *httpmock.Registry) *InstallOptions {
+				t.Helper()
+				return &InstallOptions{
+					IO:           ios,
+					HttpClient:   func() (*http.Client, error) { return &http.Client{Transport: reg}, nil },
+					GitClient:    &git.Client{RepoDir: t.TempDir()},
+					SkillSource:  "monalisa/skills-repo",
+					SkillName:    "git-commit",
+					Agent:        "generic",
+					Scope:        "user",
+					ScopeChanged: true,
+				}
+			},
+			verify: func(t *testing.T) {
+				t.Helper()
+				homeDir, err := os.UserHomeDir()
+				require.NoError(t, err)
+				_, err = os.Stat(filepath.Join(homeDir, ".agents", "skills", "git-commit", "SKILL.md"))
+				require.NoError(t, err)
+			},
+			wantStdout: "Installed git-commit",
+		},
+		{
 			name:  "remote install with --dir bypasses scope resolution",
 			isTTY: true,
 			stubs: func(reg *httpmock.Registry) {
@@ -1357,7 +1388,13 @@ func TestInstallRun(t *testing.T) {
 				t.Helper()
 				pm := &prompter.PrompterMock{
 					MultiSelectFunc: func(prompt string, defaults []string, options []string) ([]int, error) {
-						return []int{0, 1}, nil // select two agents
+						var indices []int
+						for i, label := range options {
+							if label == "GitHub Copilot" || label == "Claude Code" {
+								indices = append(indices, i)
+							}
+						}
+						return indices, nil
 					},
 					SelectFunc: func(prompt, defaultValue string, options []string) (int, error) {
 						return 0, nil // project scope

--- a/skills/gh-skill/SKILL.md
+++ b/skills/gh-skill/SKILL.md
@@ -41,8 +41,8 @@ gh skill install ./local-skills-repo --from-local
 
 Useful flags:
 
-- `--agent <id>` - target host (e.g. `github-copilot`, `claude-code`,
-  `cursor`, `codex`, `gemini-cli`). Repeat for multiple. Default is
+- `--agent <id>` - target host (e.g. `github-copilot`, `generic`,
+  `claude-code`, `cursor`, `codex`, `gemini-cli`). Repeat for multiple. Default is
   `github-copilot` when non-interactive. You should know what agent you are,
   so set this appropriately to install for yourself.
 - `--scope project|user` - `project` (default) writes inside the current

--- a/skills/gh-skill/SKILL.md
+++ b/skills/gh-skill/SKILL.md
@@ -41,7 +41,7 @@ gh skill install ./local-skills-repo --from-local
 
 Useful flags:
 
-- `--agent <id>` - target host (e.g. `github-copilot`, `generic`,
+- `--agent <id>` - target host (e.g. `github-copilot`, `generic-agent`,
   `claude-code`, `cursor`, `codex`, `gemini-cli`). Repeat for multiple. Default is
   `github-copilot` when non-interactive. You should know what agent you are,
   so set this appropriately to install for yourself.


### PR DESCRIPTION
Co-authored-by

<!--
  Thank you for contributing to GitHub CLI!
  To reference an open issue, please write this in your description: `Fixes #NUMBER`
-->
